### PR TITLE
WIP: file-based back end for bake

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -66,14 +66,6 @@ LIBS="$MARGO_LIBS $LIBS"
 CPPFLAGS="$MARGO_CFLAGS $CPPFLAGS"
 CFLAGS="$MARGO_CFLAGS $CFLAGS"
 
-# NOTE: See README.md if the following does not work for you; some versions of
-# nvml/pmem install broken .pc files
-PKG_CHECK_MODULES([LIBPMEMOBJ],[libpmemobj],[],
-   [AC_MSG_ERROR([Could not find working libpmemobj installation!])])
-LIBS="$LIBPMEMOBJ_LIBS $LIBS"
-CPPFLAGS="$LIBPMEMOBJ_CFLAGS $CPPFLAGS"
-CFLAGS="$LIBPMEMOBJ_CFLAGS $CFLAGS"
-
 PKG_CHECK_MODULES([UUID],[uuid],[],
    [AC_MSG_ERROR([Could not find working uuid installation!])])
 LIBS="$UUID_LIBS $LIBS"

--- a/include/bake-server.h
+++ b/include/bake-server.h
@@ -8,7 +8,6 @@
 #define __BAKE_SERVER_H
 
 #include <margo.h>
-#include <libpmemobj.h>
 #include <bake.h>
 
 #ifdef __cplusplus

--- a/include/bake.h
+++ b/include/bake.h
@@ -20,7 +20,7 @@ typedef struct {
 /**
  * Persistent, opaque identifier for a region within a BAKE target.
  */
-#define BAKE_REGION_ID_DATA_SIZE 24
+#define BAKE_REGION_ID_DATA_SIZE 32
 typedef struct {
     uint32_t type;
     char data[BAKE_REGION_ID_DATA_SIZE];

--- a/include/bake.h
+++ b/include/bake.h
@@ -47,6 +47,16 @@ typedef struct {
  */
 void bake_perror(char *s, int ret);
 
+/**
+ * Convert region id into printable string for debugging purposes
+ *
+ * @param[in] str string to fill in
+ * @param[in] size length of string, not including terminator.  If rid
+ *                 string is longer than this it will be truncated.
+ * @param[in] rid region_id
+ */
+void bake_print_dbg_region_id_t(char *str, size_t size, bake_region_id_t rid);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/bake.h
+++ b/include/bake.h
@@ -20,7 +20,7 @@ typedef struct {
 /**
  * Persistent, opaque identifier for a region within a BAKE target.
  */
-#define BAKE_REGION_ID_DATA_SIZE 16
+#define BAKE_REGION_ID_DATA_SIZE 24
 typedef struct {
     uint32_t type;
     char data[BAKE_REGION_ID_DATA_SIZE];
@@ -38,6 +38,7 @@ typedef struct {
 #define BAKE_ERR_OUT_OF_BOUNDS      (-9) /* Attempting an out of bound access */
 #define BAKE_ERR_REMI              (-10) /* Error related to REMI */
 #define BAKE_ERR_OP_UNSUPPORTED    (-11) /* Operation not supported */
+#define BAKE_ERR_IO                (-12) /* I/O error */
 
 /**
  * Print bake errors in human-friendly form

--- a/src/bake-client.c
+++ b/src/bake-client.c
@@ -1069,6 +1069,7 @@ int bake_noop(bake_provider_handle_t provider)
     return BAKE_SUCCESS;
 }
 
+#if 0
 static int bake_eager_read(
     bake_provider_handle_t provider,
     bake_region_id_t rid,
@@ -1133,6 +1134,7 @@ finish:
 
     return(ret);
 }
+#endif
 
 int bake_read(
     bake_provider_handle_t provider,
@@ -1149,12 +1151,11 @@ int bake_read(
     bake_read_out_t out;
     int ret;
 
-    /* read not implemented */
-    fprintf(stderr, "Error: bake_read not implemented.\n");
-    return(BAKE_ERR_OP_UNSUPPORTED);
-
+    /* no eager path with file backend */
+#if 0
     if(buf_size <= provider->eager_limit)
         return(bake_eager_read(provider, rid, region_offset, buf, buf_size, bytes_read));
+#endif
 
     TIMERS_INITIALIZE("bulk_create","forward","end");
 

--- a/src/bake-client.c
+++ b/src/bake-client.c
@@ -286,6 +286,7 @@ int bake_shutdown_service(bake_client_t client, hg_addr_t addr)
     return margo_shutdown_remote_instance(client->mid, addr);
 }
 
+#if 0
 static int bake_eager_write(
     bake_provider_handle_t provider,
     bake_region_id_t rid,
@@ -342,6 +343,7 @@ finish:
 
     return ret;
 }
+#endif
 
 int bake_write(
     bake_provider_handle_t provider,
@@ -357,8 +359,11 @@ int bake_write(
     bake_write_out_t out;
     int ret;
 
+    /* no eager for now, because it complicates file I/O alignment */
+#if 0
     if(buf_size <= provider->eager_limit)
         return(bake_eager_write(provider, rid, region_offset, buf, buf_size));
+#endif
 
     TIMERS_INITIALIZE("bulk_create", "forward", "end");
 
@@ -1144,6 +1149,10 @@ int bake_read(
     bake_read_out_t out;
     int ret;
 
+    /* read not implemented */
+    fprintf(stderr, "Error: bake_read not implemented.\n");
+    return(BAKE_ERR_OP_UNSUPPORTED);
+
     if(buf_size <= provider->eager_limit)
         return(bake_eager_read(provider, rid, region_offset, buf, buf_size, bytes_read));
 
@@ -1275,6 +1284,10 @@ int bake_remove(
     bake_remove_in_t in;
     bake_remove_out_t out;
     int ret;
+
+    /* remove not implemented */
+    fprintf(stderr, "Error: bake_remove not implemented.\n");
+    return(BAKE_ERR_OP_UNSUPPORTED);
 
     in.rid = rid;
 

--- a/src/bake-client.c
+++ b/src/bake-client.c
@@ -1286,10 +1286,6 @@ int bake_remove(
     bake_remove_out_t out;
     int ret;
 
-    /* remove not implemented */
-    fprintf(stderr, "Error: bake_remove not implemented.\n");
-    return(BAKE_ERR_OP_UNSUPPORTED);
-
     in.rid = rid;
 
     hret = margo_create(provider->client->mid, provider->addr,

--- a/src/bake-copy-from.c
+++ b/src/bake-copy-from.c
@@ -36,17 +36,21 @@ int main(int argc, char **argv)
     char* local_region;
     int region_fd;
     uint64_t size;
+    uint64_t offset = 0;
     char region_str[128];
  
-    if(argc != 6)
+    if(argc != 6 && argc != 7)
     {
-        fprintf(stderr, "Usage: bake-copy-from <server addr> <mplex id> <identifier file> <output file> <size>\n");
+        fprintf(stderr, "Usage: bake-copy-from <server addr> <mplex id> <identifier file> <output file> <size> [optional_offset]\n");
         fprintf(stderr, "  Example: ./bake-copy-from tcp://localhost:1234 3 /tmp/bb-copy-rid.0GjOlu /tmp/output.dat 256\n");
+        fprintf(stderr, "  NOTE: if optional_offset is specified, then data will be read from that offset within the source region.\n");
         return(-1);
     }
     svr_addr_str = argv[1];
     mplex_id = atoi(argv[2]);
     size = atol(argv[5]);
+    if(argc == 7)
+        offset = atol(argv[6]);
 
     /* initialize Margo using the transport portion of the server
      * address (i.e., the part before the first : character if present)
@@ -177,7 +181,7 @@ int main(int argc, char **argv)
     ret = bake_read(
         bph,
         rid,
-        0,
+        offset,
         local_region,
         size,
         &bytes_read);

--- a/src/bake-copy-from.c
+++ b/src/bake-copy-from.c
@@ -36,6 +36,7 @@ int main(int argc, char **argv)
     char* local_region;
     int region_fd;
     uint64_t size;
+    char region_str[128];
  
     if(argc != 6)
     {
@@ -110,6 +111,9 @@ int main(int argc, char **argv)
         return(-1);
     }
     close(region_fd);
+
+    bake_print_dbg_region_id_t(region_str, 127, rid);
+    printf("# will read bake region %s\n", region_str);
 
 #ifdef USE_SIZECHECK_HEADERS
     uint64_t check_size;

--- a/src/bake-copy-to.c
+++ b/src/bake-copy-to.c
@@ -38,6 +38,7 @@ int main(int argc, char **argv)
     char* local_region;
     int region_fd;
     char region_file[128];
+    char region_str[128];
 #ifdef USE_SIZECHECK_HEADERS
     uint64_t  check_size;
 #endif
@@ -161,6 +162,9 @@ int main(int argc, char **argv)
         bake_perror("Error: bake_create()", ret);
         return(-1);
     }
+
+    bake_print_dbg_region_id_t(region_str, 127, rid);
+    printf("# created bake region %s\n", region_str);
 
     /* transfer data */
     ret = bake_write(

--- a/src/bake-copy-to.c
+++ b/src/bake-copy-to.c
@@ -56,7 +56,7 @@ int main(int argc, char **argv)
     uint64_t num_targets;
     bake_target_id_t bti[target_number];
 
-    fd = open(argv[1], O_RDONLY);
+    fd = open(argv[1], O_RDWR);
     if(fd < 0)
     {
         perror("open");
@@ -70,7 +70,7 @@ int main(int argc, char **argv)
         return(-1);
     }
 
-    local_region = mmap(NULL, statbuf.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
+    local_region = mmap(NULL, statbuf.st_size, PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0);
     if(local_region == MAP_FAILED)
     {
         perror("mmap");

--- a/src/bake-copy-to.c
+++ b/src/bake-copy-to.c
@@ -70,7 +70,7 @@ int main(int argc, char **argv)
         return(-1);
     }
 
-    local_region = mmap(NULL, statbuf.st_size, PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0);
+    local_region = mmap(NULL, statbuf.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
     if(local_region == MAP_FAILED)
     {
         perror("mmap");

--- a/src/bake-copy-to.c
+++ b/src/bake-copy-to.c
@@ -70,7 +70,7 @@ int main(int argc, char **argv)
         return(-1);
     }
 
-    local_region = mmap(NULL, statbuf.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
+    local_region = mmap(NULL, statbuf.st_size, PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0);
     if(local_region == MAP_FAILED)
     {
         perror("mmap");

--- a/src/bake-mkpool.c
+++ b/src/bake-mkpool.c
@@ -10,7 +10,6 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
-#include <libpmemobj.h>
 #include <bake-server.h>
 
 struct options

--- a/src/bake-server-daemon.c
+++ b/src/bake-server-daemon.c
@@ -10,7 +10,6 @@
 #include <assert.h>
 #include <unistd.h>
 #include <margo.h>
-#include <libpmemobj.h>
 #include <bake-server.h>
 
 typedef enum {

--- a/src/bake-server.c
+++ b/src/bake-server.c
@@ -60,7 +60,7 @@ typedef struct
 {
     bake_target_id_t target_id;
     off_t offset;
-    size_t size;
+    size_t log_entry_size;
 } pmemobj_region_id_t;
 
 typedef struct {
@@ -572,7 +572,7 @@ static void bake_create_ult(hg_handle_t handle)
      * that this space is still reserved after a restart.
      */
     prid->offset = entry->log_offset;
-    prid->size = in.region_size;
+    prid->log_entry_size = content_size;
     prid->target_id = in.bti;
     ABT_mutex_lock(entry->log_offset_mutex);
     entry->log_offset += content_size;
@@ -1002,7 +1002,7 @@ static void bake_create_write_persist_ult(hg_handle_t handle)
      * that this space is still reserved after a restart.
      */
     prid->offset = entry->log_offset;
-    prid->size = in.region_size;
+    prid->log_entry_size = content_size;
     prid->target_id = in.bti;
     ABT_mutex_lock(entry->log_offset_mutex);
     entry->log_offset += content_size;
@@ -1631,7 +1631,7 @@ static void bake_remove_ult(hg_handle_t handle)
     entry = find_pmem_entry(svr_ctx, prid->target_id);
     assert(entry);
 
-    out.ret = abt_io_fallocate(entry->abtioi, entry->log_fd, FALLOC_FL_PUNCH_HOLE|FALLOC_FL_KEEP_SIZE, prid->offset, prid->size);
+    out.ret = abt_io_fallocate(entry->abtioi, entry->log_fd, FALLOC_FL_PUNCH_HOLE|FALLOC_FL_KEEP_SIZE, prid->offset, prid->log_entry_size);
 
     TIMERS_END_STEP(1);
 

--- a/src/bake-server.c
+++ b/src/bake-server.c
@@ -13,6 +13,7 @@
 #define _GNU_SOURCE
 
 #define PAGE_ROUND_UP(x) ( (((unsigned long)(x)) + 4095)  & (~(4095)) )
+#define PAGE_ROUND_DOWN(x) ((unsigned long)(x) & (~(4095)))
 
 #include "bake-config.h"
 

--- a/src/bake-server.c
+++ b/src/bake-server.c
@@ -18,7 +18,6 @@
 #include "bake-config.h"
 
 #include <assert.h>
-#include <libpmemobj.h>
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/src/bake-server.c
+++ b/src/bake-server.c
@@ -781,6 +781,13 @@ static void bake_write_ult(hg_handle_t handle)
     entry = find_pmem_entry(svr_ctx, prid->target_id);
     assert(entry);
 
+    /* TODO: need to come back and implement logic to allow writes that don't
+     * start at the beginning of the log entry.  This is trickier than the
+     * read case, because the offset isn't necessarily aligned, and we may
+     * have to do read/modify/writes.
+     */
+    assert(in.region_offset == 0);
+
     out.ret = transfer_data(mid, svr_ctx, entry->abtioi, entry->log_fd, prid->offset, in.region_offset, in.bulk_handle, in.bulk_offset,
         in.bulk_size, in.remote_addr_str, hgi->addr, handler_pool, TRANSFER_DATA_WRITE);
     TIMERS_END_STEP(1);

--- a/src/bake-server.c
+++ b/src/bake-server.c
@@ -60,6 +60,7 @@ typedef struct
 {
     bake_target_id_t target_id;
     off_t offset;
+    size_t size;
 } pmemobj_region_id_t;
 
 typedef struct {
@@ -571,6 +572,7 @@ static void bake_create_ult(hg_handle_t handle)
      * that this space is still reserved after a restart.
      */
     prid->offset = entry->log_offset;
+    prid->size = in.region_size;
     prid->target_id = in.bti;
     ABT_mutex_lock(entry->log_offset_mutex);
     entry->log_offset += content_size;
@@ -1000,6 +1002,7 @@ static void bake_create_write_persist_ult(hg_handle_t handle)
      * that this space is still reserved after a restart.
      */
     prid->offset = entry->log_offset;
+    prid->size = in.region_size;
     prid->target_id = in.bti;
     ABT_mutex_lock(entry->log_offset_mutex);
     entry->log_offset += content_size;

--- a/src/bake-server.c
+++ b/src/bake-server.c
@@ -1334,7 +1334,7 @@ static void bake_read_ult(hg_handle_t handle)
     assert(in.region_offset == 0);
 
     out.ret = transfer_data(mid, svr_ctx, entry->abtioi, entry->log_fd, prid->offset, in.region_offset, in.bulk_handle, in.bulk_offset,
-        in.bulk_size, in.remote_addr_str, hgi->addr, handler_pool, TRANSFER_DATA_WRITE);
+        in.bulk_size, in.remote_addr_str, hgi->addr, handler_pool, TRANSFER_DATA_READ);
     TIMERS_END_STEP(1);
 
 finish:

--- a/src/bake-server.c
+++ b/src/bake-server.c
@@ -1921,6 +1921,11 @@ static void xfer_ult(void *_args)
         /* shouldn't ever fail in this use case */
         assert(ret == 0);
 
+        /* TODO: we need to get aligned buffers out of the margo buffer
+         * pool.  Need a way to specify this.
+         */
+        assert((long unsigned)local_bulk_ptr % 4096 == 0);
+
         /* do the rdma transfer */
         ret = margo_bulk_transfer(args->mid, HG_BULK_PULL,
             args->remote_addr, args->remote_bulk,

--- a/src/bake-server.c
+++ b/src/bake-server.c
@@ -583,10 +583,10 @@ static void bake_create_ult(hg_handle_t handle)
      * reserved by the log increment, or to fallocate to make sure the log
      * file is at least that big.
      */
-    prid->offset = entry->log_offset;
     prid->log_entry_size = content_size;
     prid->target_id = in.bti;
     ABT_mutex_lock(entry->log_offset_mutex);
+    prid->offset = entry->log_offset;
     entry->log_offset += content_size;
     ABT_mutex_unlock(entry->log_offset_mutex);
 

--- a/src/bake-server.c
+++ b/src/bake-server.c
@@ -570,6 +570,10 @@ static void bake_create_ult(hg_handle_t handle)
     
     /* TODO: technically we should persist the log increment somewhere so
      * that this space is still reserved after a restart.
+     *
+     * TODO: one approach would be to write a zero page at the end of the space
+     * reserved by the log increment, or to fallocate to make sure the log
+     * file is at least that big.
      */
     prid->offset = entry->log_offset;
     prid->log_entry_size = content_size;
@@ -1007,6 +1011,10 @@ static void bake_create_write_persist_ult(hg_handle_t handle)
     
     /* TODO: technically we should persist the log increment somewhere so
      * that this space is still reserved after a restart.
+     *
+     * TODO: one approach would be to write a zero page at the end of the space
+     * reserved by the log increment, or to fallocate to make sure the log
+     * file is at least that big.
      */
     prid->offset = entry->log_offset;
     prid->log_entry_size = content_size;

--- a/src/bake-server.c
+++ b/src/bake-server.c
@@ -1374,6 +1374,7 @@ static void bake_read_ult(hg_handle_t handle)
 
     out.ret = transfer_data(mid, svr_ctx, entry->abtioi, entry->log_fd, prid->offset, in.region_offset, in.bulk_handle, in.bulk_offset,
         in.bulk_size, in.remote_addr_str, hgi->addr, handler_pool, TRANSFER_DATA_READ);
+    out.size = in.bulk_size - in.bulk_offset;
     TIMERS_END_STEP(1);
 
 finish:

--- a/src/util.c
+++ b/src/util.c
@@ -8,7 +8,6 @@
 #include "bake.h"
 #include <stdio.h>
 #include <inttypes.h>
-#include <libpmemobj.h>
 
 static char * bake_err_str(int ret)
 {
@@ -71,12 +70,15 @@ void bake_perror(char *s, int err)
 
 void bake_print_dbg_region_id_t(char *str, size_t size, bake_region_id_t rid)
 {
+#if 1
+    snprintf( str, size, "UNKNOWN");
+#else
     PMEMoid *oid;
 
     /* NOTE: this is fragile.  Would break if pmemobj format changes. */
     oid = (PMEMoid *)rid.data;
 
     snprintf(str, size, "%u:%" PRIu64 ":%" PRIu64, rid.type, oid->pool_uuid_lo, oid->off);
-
+#endif
     return;
 }

--- a/src/util.c
+++ b/src/util.c
@@ -49,6 +49,9 @@ static char * bake_err_str(int ret)
         case BAKE_ERR_OP_UNSUPPORTED:
             return "Operation not supported";
             break;
+        case BAKE_ERR_IO:
+            return "I/O error";
+            break;
         default:
             return "Unknown error";
             break;

--- a/src/util.c
+++ b/src/util.c
@@ -7,6 +7,8 @@
 #include "bake-config.h"
 #include "bake.h"
 #include <stdio.h>
+#include <inttypes.h>
+#include <libpmemobj.h>
 
 static char * bake_err_str(int ret)
 {
@@ -64,3 +66,14 @@ void bake_perror(char *s, int err)
     fprintf(stderr, "%s\n", error_string);
 }
 
+void bake_print_dbg_region_id_t(char *str, size_t size, bake_region_id_t rid)
+{
+    PMEMoid *oid;
+
+    /* NOTE: this is fragile.  Would break if pmemobj format changes. */
+    oid = (PMEMoid *)rid.data;
+
+    snprintf(str, size, "%u:%" PRIu64 ":%" PRIu64, rid.type, oid->pool_uuid_lo, oid->off);
+
+    return;
+}

--- a/tests/create-write-persist-remove.sh
+++ b/tests/create-write-persist-remove.sh
@@ -28,11 +28,11 @@ wait
 # check that the underlying pool is empty since we removed the object during the test
 # XXX note this assumes pmem pools -- may want to write our
 # own wrapper for this functionality at some point
-num_objs=`pmempool info -ns $TMPBASE/svr-1.dat | grep "Number of objects" | head -n 1 | cut -d: -f2 | awk '{$1=$1};1'`
-if [ $num_objs -ne 0 ]; then
-    echo "Expected the BAKE pool to be empty"
-    exit 1
-fi
+# num_objs=`pmempool info -ns $TMPBASE/svr-1.dat | grep "Number of objects" | head -n 1 | cut -d: -f2 | awk '{$1=$1};1'`
+# if [ $num_objs -ne 0 ]; then
+#     echo "Expected the BAKE pool to be empty"
+#     exit 1
+# fi
 
 echo cleaning up $TMPBASE
 rm -rf $TMPBASE

--- a/tests/create-write-persist.sh
+++ b/tests/create-write-persist.sh
@@ -28,11 +28,11 @@ wait
 # check that the underlying pool has the object we created
 # XXX note this assumes pmem pools -- may want to write our
 # own wrapper for this functionality at some point
-num_objs=`pmempool info -ns $TMPBASE/svr-1.dat | grep "Number of objects" | head -n 1 | cut -d: -f2 | awk '{$1=$1};1'`
-if [ $num_objs -ne 1 ]; then
-    echo "Invalid number of objects in BAKE pool"
-    exit 1
-fi
+# num_objs=`pmempool info -ns $TMPBASE/svr-1.dat | grep "Number of objects" | head -n 1 | cut -d: -f2 | awk '{$1=$1};1'`
+# if [ $num_objs -ne 1 ]; then
+#     echo "Invalid number of objects in BAKE pool"
+#     exit 1
+# fi
 
 echo cleaning up $TMPBASE
 rm -rf $TMPBASE

--- a/tests/proxy/proxy-server-daemon.c
+++ b/tests/proxy/proxy-server-daemon.c
@@ -9,7 +9,6 @@
 #include <unistd.h>
 #include <uuid/uuid.h>
 #include <margo.h>
-#include <libpmemobj.h>
 #include <bake-client.h>
 
 #include "proxy-rpc.h"

--- a/tests/test-util.sh
+++ b/tests/test-util.sh
@@ -12,7 +12,7 @@ if [ -z "$MKTEMP" ] ; then
     exit 1
 fi
 
-TMPDIR=/dev/shm
+TMPDIR=/tmp
 export TMPDIR
 mkdir -p $TMPDIR
 TMPBASE=$(${MKTEMP} --tmpdir -d test-XXXXXX)


### PR DESCRIPTION
In GitLab by @carns on May 14, 2019, 13:31

Do not merge; this is a prototype for preliminary performance testing.

The point of this experiment is to have the ability to store regions in normal POSIX files using O_DIRECT as an alternative to storing regions in libpmemobj objects.

This branch does not implement reads, removes, eager operations, or size checks.  It is just enough for write performance benchmarking.

All regions are stored in a single log-structured files, with pwrite() and fdatasync() calls serviced via an abt-io instance backed by 8 execution streams.

Required: run with pipelining enabled.  Recommended: run with no dedicated threads for RPC handling.