### PR TITLE
WIP: multi-log file backend

### DIFF
--- a/include/bake.h
+++ b/include/bake.h
@@ -20,7 +20,7 @@ typedef struct {
 /**
  * Persistent, opaque identifier for a region within a BAKE target.
  */
-#define BAKE_REGION_ID_DATA_SIZE 16
+#define BAKE_REGION_ID_DATA_SIZE 24
 typedef struct {
     uint32_t type;
     char data[BAKE_REGION_ID_DATA_SIZE];

--- a/tests/basic-file.sh
+++ b/tests/basic-file.sh
@@ -9,8 +9,8 @@ fi
 export TMPDIR="."
 source $srcdir/tests/test-util.sh
 
-# start 1 server with 2 second wait, 20s timeout
-test_start_servers 1 2 20 file:
+# start 1 server with 4 second wait, 20s timeout
+test_start_servers 1 4 20 file:
 
 sleep 1
 

--- a/tests/copy-to-and-from-file.sh
+++ b/tests/copy-to-and-from-file.sh
@@ -9,8 +9,8 @@ fi
 export TMPDIR="."
 source $srcdir/tests/test-util.sh
 
-# start 1 server with 2 second wait, 20s timeout
-test_start_servers 1 2 20 file:
+# start 1 server with 4 second wait, 20s timeout
+test_start_servers 1 4 20 file:
 
 # actual test case
 #####################

--- a/tests/copy-to-and-from-multi-providers-file.sh
+++ b/tests/copy-to-and-from-multi-providers-file.sh
@@ -9,8 +9,8 @@ fi
 export TMPDIR="."
 source $srcdir/tests/test-util.sh
 
-# start 1 server with 2 providers, 2 second wait, 20s timeout
-test_start_servers_multi_providers 1 2 2 20 file:
+# start 1 server with 2 providers, 4 second wait, 20s timeout
+test_start_servers_multi_providers 1 2 4 20 file:
 
 # actual test case
 #####################

--- a/tests/copy-to-and-from-multi-targets-file.sh
+++ b/tests/copy-to-and-from-multi-targets-file.sh
@@ -9,8 +9,8 @@ fi
 export TMPDIR="."
 source $srcdir/tests/test-util.sh
 
-# start 1 server with 2 targets, 2 second wait, 20s timeout
-test_start_servers_multi_targets 1 2 2 20 file:
+# start 1 server with 2 targets, 4 second wait, 20s timeout
+test_start_servers_multi_targets 1 2 4 20 file:
 
 # actual test case
 #####################

--- a/tests/create-write-persist-file.sh
+++ b/tests/create-write-persist-file.sh
@@ -12,8 +12,8 @@ fi
 export TMPDIR="."
 source $srcdir/tests/test-util.sh
 
-# start 1 server with 2 second wait, 20s timeout
-test_start_servers 1 2 20 file:
+# start 1 server with 4 second wait, 20s timeout
+test_start_servers 1 4 20 file:
 
 sleep 1
 

--- a/tests/create-write-persist-remove-file.sh
+++ b/tests/create-write-persist-remove-file.sh
@@ -12,8 +12,8 @@ fi
 export TMPDIR="."
 source $srcdir/tests/test-util.sh
 
-# start 1 server with 2 second wait, 20s timeout
-test_start_servers 1 2 20 file:
+# start 1 server with 4 second wait, 20s timeout
+test_start_servers 1 4 20 file:
 
 sleep 1
 


### PR DESCRIPTION
In GitLab by @carns on Jun 3, 2020, 22:50

Tracking this as a WIP mainly so that we don't lose this.  The idea is to use N backing logs instead of just one, pre-allocate them to an initial size, and then extend them in bulk as needed.

The changes in this WIP are only enough for limited proof of concept benchmarks, but the performance boost is significant (from 150 to 540 MiB/s write bandwidth in point to point tests with 32 KiB access size).

Further changes needed:
* implement asynchronous fallocate to extend logs when their capacity reaches a configurable threshold
* configuration variables for number of logs and initial size
* store current log record offset on clean shutdown, retrieve it and clear it on clean startup
* set log record offset to end of current log file for safety if exact log position cannot be found
* fix multi-target and multi-provider modes