### PR TITLE
add provider set_param() function and ability to start daemon with json provider config

### DIFF
--- a/examples/bake-server-daemon-example.json
+++ b/examples/bake-server-daemon-example.json
@@ -1,0 +1,15 @@
+{
+  "version":"0.6.1",
+  "pipeline_enable":true,
+  "pipeline_npools":4,
+  "pipeline_nbuffers_per_pool":32,
+  "pipeline_first_buffer_size":65536,
+  "pipeline_multiplier":4,
+  "file_backend":{
+    "targets":[
+      "file.dat"
+    ],
+    "alignment":4096,
+    "abtio_nthreads":16
+  }
+}

--- a/include/bake-server.h
+++ b/include/bake-server.h
@@ -164,6 +164,18 @@ int bake_provider_list_targets(bake_provider_t   provider,
                                bake_target_id_t* targets);
 
 /**
+ * Sets configuration parameters
+ *
+ * @param [in] provider Bake provider
+ * @param [in] key parameter name
+ * @param [in] value parameter value
+ *
+ * @returns 0 on success, -1 on failure
+ */
+int bake_provider_set_param(bake_provider_t provider,
+                            const char*     key,
+                            const char*     value);
+/**
  * Retrieves complete configuration of bake provider, encoded as json
  *
  * @param [in] provider bake provider

--- a/src/bake-macros.h
+++ b/src/bake-macros.h
@@ -99,4 +99,25 @@ static const int json_type_int64 = json_type_int;
         json_object_object_add(__config, __key, _tmp);                       \
     } while (0)
 
+// Overrides a field with a boolean. If the field already existed and was
+// different from the new value, and __warning is true, prints a warning.
+#define CONFIG_OVERRIDE_BOOL(__config, __key, __value, __field_name,         \
+                             __warning)                                      \
+    do {                                                                     \
+        struct json_object* _tmp = json_object_object_get(__config, __key);  \
+        if (_tmp && __warning) {                                             \
+            if (!json_object_is_type(_tmp, json_type_boolean))               \
+                BAKE_WARNING(0, "Overriding field \"%s\" with value \"%s\"", \
+                             __field_name, __value ? "true" : "false");      \
+            else if (json_object_get_boolean(_tmp) != !!__value)             \
+                BAKE_WARNING(                                                \
+                    0, "Overriding field \"%s\" (\"%s\") with value \"%s\"", \
+                    __field_name,                                            \
+                    json_object_get_boolean(_tmp) ? "true" : "false",        \
+                    __value ? "true" : "false");                             \
+        }                                                                    \
+        json_object_object_add(__config, __key,                              \
+                               json_object_new_boolean(__value));            \
+    } while (0)
+
 #endif /* __BAKE_MACROS */

--- a/src/bake-server-daemon.c
+++ b/src/bake-server-daemon.c
@@ -161,21 +161,25 @@ int main(int argc, char** argv)
         int i;
         for (i = 0; i < opts.num_pools; i++) {
             bake_target_id_t               tid;
-            struct bake_provider_init_info bpargs           = {0};
-            char                           json_config[256] = {0};
-
-            if (opts.pipeline_enabled) {
-                sprintf(json_config, "{\"pipeline_enable\": true}");
-                bpargs.json_config = json_config;
-            }
+            struct bake_provider_init_info bpargs = {0};
 
             ret = bake_provider_register(mid, i + 1, &bpargs, &provider);
-
             if (ret != 0) {
                 bake_perror("Error: bake_provider_register()", ret);
                 free(opts.bake_pools);
                 margo_finalize(mid);
                 return (-1);
+            }
+
+            if (opts.pipeline_enabled) {
+                ret = bake_provider_set_param(provider, "pipeline_enable",
+                                              "true");
+                if (ret != 0) {
+                    bake_perror("Error: bake_provider_set_param()", ret);
+                    free(opts.bake_pools);
+                    margo_finalize(mid);
+                    return (-1);
+                }
             }
 
             ret = bake_provider_attach_target(provider, opts.bake_pools[i],
@@ -195,21 +199,24 @@ int main(int argc, char** argv)
     } else {
 
         int                            i;
-        struct bake_provider_init_info bpargs           = {0};
-        char                           json_config[256] = {0};
-
-        if (opts.pipeline_enabled) {
-            sprintf(json_config, "{\"pipeline_enable\": true}");
-            bpargs.json_config = json_config;
-        }
+        struct bake_provider_init_info bpargs = {0};
 
         ret = bake_provider_register(mid, 1, &bpargs, &provider);
-
         if (ret != 0) {
             bake_perror("Error: bake_provider_register()", ret);
             free(opts.bake_pools);
             margo_finalize(mid);
             return (-1);
+        }
+
+        if (opts.pipeline_enabled) {
+            ret = bake_provider_set_param(provider, "pipeline_enable", "true");
+            if (ret != 0) {
+                bake_perror("Error: bake_provider_set_param()", ret);
+                free(opts.bake_pools);
+                margo_finalize(mid);
+                return (-1);
+            }
         }
 
         for (i = 0; i < opts.num_pools; i++) {


### PR DESCRIPTION
* the set_param() function allows supported provider parameters to be modified at runtime
* the -j option to bake-server-daemon is mainly for development purposes to make it easier to quickly test json parameters without using bedrock